### PR TITLE
Add ignore-names option

### DIFF
--- a/testsuite/N802.py
+++ b/testsuite/N802.py
@@ -52,3 +52,10 @@ class ClassName(object):
     def method(self):
         def __bad():
             pass
+#: Okay
+def setUp():
+    pass
+
+#: Okay
+def tearDown():
+    pass


### PR DESCRIPTION
This configuration option allows to skip certain function names.

This fixes https://github.com/flintwork/pep8-naming/issues/6

Consider this a WIP. If the approach is ok I will add the same logic to other error types, namely:

- N801 class names should use CapWords convention *TBD (you can not always control this)*
- N802 function name should be lowercase **(done)**
- N803 argument name should be lowercase *TBD (ditto as 801)*
- N806 variable in function should be lowercase *I don't think it makes sense, right?*

Any other error should be also check for names to skip?