### PR TITLE
Fix the way ignored names are split

### DIFF
--- a/pep8ext_naming.py
+++ b/pep8ext_naming.py
@@ -15,6 +15,7 @@ __version__ = '0.3.2'
 LOWERCASE_REGEX = re.compile(r'[_a-z][_a-z0-9]*$')
 UPPERCASE_REGEX = re.compile(r'[_A-Z][_A-Z0-9]*$')
 MIXEDCASE_REGEX = re.compile(r'_?[A-Z][a-zA-Z0-9]*$')
+SPLIT_IGNORED_RE = re.compile(r'[,\s]')
 
 
 if sys.version_info[0] < 3:
@@ -78,7 +79,7 @@ class NamingChecker(object):
 
     @classmethod
     def parse_options(cls, options):
-        cls.ignore_names = options.ignore_names.split(', ')
+        cls.ignore_names = SPLIT_IGNORED_RE.split(options.ignore_names)
 
     def run(self):
         return self.visit_tree(self._node) if self._node else ()


### PR DESCRIPTION
[As noted on this commit][0], the default ignored names were combined using `','.join` and then split using `.split(', ')` which was not splitting the names correctly. 
```
>>> ','.join(['foo', 'bar']).split(', ')
['foo,bar']
```
This adjusts the splitting to allow both space and commas.

[0]: https://github.com/flintwork/pep8-naming/commit/984f603dbd94ebfa291bbcb3cf32be61bfbe74ee#commitcomment-11799619